### PR TITLE
Support Teensy 3.x & fix null pointer write

### DIFF
--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -54,6 +54,8 @@ void Adafruit_ILI9341::spiwrite(uint8_t c) {
     SPDR = c;
     while(!(SPSR & _BV(SPIF)));
     SPCR = backupSPCR;
+#elif defined(TEENSYDUINO)
+    SPI.transfer(c);
 #elif defined (__arm__)
     SPI.setClockDivider(11); // 8-ish MHz (full! speed!)
     SPI.setBitOrder(MSBFIRST);
@@ -82,7 +84,7 @@ void Adafruit_ILI9341::spiwrite(uint8_t c) {
 void Adafruit_ILI9341::writecommand(uint8_t c) {
   *dcport &=  ~dcpinmask;
   //digitalWrite(_dc, LOW);
-  *clkport &= ~clkpinmask;
+  //*clkport &= ~clkpinmask; // clkport is a NULL pointer when hwSPI==true
   //digitalWrite(_sclk, LOW);
   *csport &= ~cspinmask;
   //digitalWrite(_cs, LOW);
@@ -97,7 +99,7 @@ void Adafruit_ILI9341::writecommand(uint8_t c) {
 void Adafruit_ILI9341::writedata(uint8_t c) {
   *dcport |=  dcpinmask;
   //digitalWrite(_dc, HIGH);
-  *clkport &= ~clkpinmask;
+  //*clkport &= ~clkpinmask; // clkport is a NULL pointer when hwSPI==true
   //digitalWrite(_sclk, LOW);
   *csport &= ~cspinmask;
   //digitalWrite(_cs, LOW);
@@ -163,6 +165,11 @@ void Adafruit_ILI9341::begin(void) {
     SPI.setBitOrder(MSBFIRST);
     SPI.setDataMode(SPI_MODE0);
     mySPCR = SPCR;
+#elif defined(TEENSYDUINO)
+    SPI.begin();
+    SPI.setClockDivider(SPI_CLOCK_DIV2); // 8 MHz (full! speed!)
+    SPI.setBitOrder(MSBFIRST);
+    SPI.setDataMode(SPI_MODE0);
 #elif defined (__arm__)
       SPI.begin();
       SPI.setClockDivider(11); // 8-ish MHz (full! speed!)
@@ -509,6 +516,8 @@ uint8_t Adafruit_ILI9341::spiread(void) {
     while(!(SPSR & _BV(SPIF)));
     r = SPDR;
     SPCR = backupSPCR;
+#elif defined(TEENSYDUINO)
+    r = SPI.transfer(0x00);
 #elif defined (__arm__)
     SPI.setClockDivider(11); // 8-ish MHz (full! speed!)
     SPI.setBitOrder(MSBFIRST);

--- a/Adafruit_ILI9341.h
+++ b/Adafruit_ILI9341.h
@@ -139,7 +139,7 @@ class Adafruit_ILI9341 : public Adafruit_GFX {
 
 
   boolean  hwSPI;
-#if defined (__AVR__)
+#if defined (__AVR__) || defined(TEENSYDUINO)
   uint8_t mySPCR;
   volatile uint8_t *mosiport, *clkport, *dcport, *rsport, *csport;
   int8_t  _cs, _dc, _rst, _mosi, _miso, _sclk;


### PR DESCRIPTION
This pull request restores Teensy 3.x support, which broke when Arduino Due was added.

Somehow writes to the "clkport" pointer got into the higher level code.  When hwSPI is true, clkport defaults to a NULL pointer.  On AVR, this merely overwrites registers.  On ARM, it creates a memory fault, since the flash memory isn't writable.  I'm not sure what the original intention of writing to clkport was in that code, but doing it there is certainly a bug on all platforms.  I commented out these clkport writes.
