### PR TITLE
ESP8266 fix and speed-ups (up to 57% faster)

### DIFF
--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -69,7 +69,7 @@ Adafruit_ILI9341::Adafruit_ILI9341(int8_t cs, int8_t dc, int8_t rst) : Adafruit_
   _dc   = dc;
   _rst  = rst;
   hwSPI = true;
-  _mosi  = _sclk = 0;
+  _mosi  = _sclk = -1;
 }
 
 void Adafruit_ILI9341::spiwrite(uint8_t c) {

--- a/Adafruit_ILI9341.h
+++ b/Adafruit_ILI9341.h
@@ -30,7 +30,7 @@
 #endif
 
 
-#if defined (__AVR__) || defined(TEENSYDUINO) || defined (__arm__)
+#if defined (__AVR__) || defined(TEENSYDUINO) || defined (__arm__) || defined (ESP8266)
 #define USE_FAST_PINIO
 #endif
 
@@ -146,6 +146,7 @@ class Adafruit_ILI9341 : public Adafruit_GFX {
   */
 
   void     spiwrite(uint8_t),
+    spiwrite16(uint16_t),
     writecommand(uint8_t c),
     writedata(uint8_t d),
     commandList(uint8_t *addr);
@@ -175,6 +176,8 @@ class Adafruit_ILI9341 : public Adafruit_GFX {
     int8_t  _cs, _dc, _rst, _mosi, _miso, _sclk;
 #elif defined (ESP8266)
     int32_t  _cs, _dc, _rst, _mosi, _miso, _sclk;
+    volatile uint32_t *mosiport, *clkport, *dcport, *rsport, *csport;
+    uint32_t  mosipinmask, clkpinmask, cspinmask, dcpinmask;
 #endif
 };
 


### PR DESCRIPTION
The original code has the line `_mosi = _sclk = 0;` when using HWSPI, but that breaks things on the ESP8266 where GPIO0 is actually useable, so I set _mosi and _sclk to -1 instead.

As for the speed-ups: define USE_FAST_PINIO for the ESP8266, use faster SPI-clock and add a new function called spiwrite16, which on non-ESP8266 just does two spiwrite()-calls, just like the code already does, but on the ESP8266 uses the proper SPI.write16()-call, which results in major speed-ups. This way also allows any other devices that implement a similar call to benefit from speed-ups, all you have to do is modify the spiwrite16()-call.

Original ILI9341:
Screen fill              1545712
Text                     100791
Lines                    995059
Horiz/Vert Lines         126297
Rectangles (outline)     81350
Rectangles (filled)      3200299
Circles (filled)         502262
Circles (outline)        434495
Triangles (outline)      315384
Triangles (filled)       1067558
Rounded rects (outline)  186570
Rounded rects (filled)   3498914

Faster SPI-clock:
Screen fill              1228514
Text                     86081
Lines                    855910
Horiz/Vert Lines         100460
Rectangles (outline)     64933
Rectangles (filled)      2542491
Circles (filled)         412466
Circles (outline)        373598
Triangles (outline)      271226
Triangles (filled)       854875
Rounded rects (outline)  156747
Rounded rects (filled)   2783075

SPI-clock + FAST_PINIO:
Screen fill              1228612
Text                     80858
Lines                    795018
Horiz/Vert Lines         99815
Rectangles (outline)     64314
Rectangles (filled)      2542452
Circles (filled)         398574
Circles (outline)        347017
Triangles (outline)      251978
Triangles (filled)       844978
Rounded rects (outline)  148596
Rounded rects (filled)   2775610

SPI-clock + FAST_PINIO + spiwrite16:
Screen fill              661778
Text                     72879
Lines                    760434
Horiz/Vert Lines         55280
Rectangles (outline)     36734
Rectangles (filled)      1366593
Circles (filled)         284821
Circles (outline)        331897
Triangles (outline)      241019
Triangles (filled)       494629
Rounded rects (outline)  123757
Rounded rects (filled)   1516511

Screen fill improvement: ~57%
Text improvement: ~28%
Lines improvement: ~24%
Horiz/Vert lines improvement: ~56%
Rectangles (outline) improvement: ~55%
Rectangles (filled) improvement: ~57%

And so on.