### PR TITLE
Fix for GPIO and enable FAST_PINIO for ESP8266

### DIFF
--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -69,7 +69,7 @@ Adafruit_ILI9341::Adafruit_ILI9341(int8_t cs, int8_t dc, int8_t rst) : Adafruit_
   _dc   = dc;
   _rst  = rst;
   hwSPI = true;
-  _mosi  = _sclk = 0;
+  _mosi  = _sclk = -1;
 }
 
 void Adafruit_ILI9341::spiwrite(uint8_t c) {

--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -91,7 +91,7 @@ void Adafruit_ILI9341::spiwrite(uint8_t c) {
     SPI.transfer(c);
 #endif
   } else {
-#if defined(ESP8266) || defined (ARDUINO_ARCH_ARC32)
+#if defined (ARDUINO_ARCH_ARC32)
     for(uint8_t bit = 0x80; bit; bit >>= 1) {
       if(c & bit) {
 	digitalWrite(_mosi, HIGH); 

--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -69,7 +69,7 @@ Adafruit_ILI9341::Adafruit_ILI9341(int8_t cs, int8_t dc, int8_t rst) : Adafruit_
   _dc   = dc;
   _rst  = rst;
   hwSPI = true;
-  _mosi  = _sclk = -1;
+  _mosi  = _sclk = 0;
 }
 
 void Adafruit_ILI9341::spiwrite(uint8_t c) {
@@ -127,7 +127,7 @@ void Adafruit_ILI9341::writecommand(uint8_t c) {
   *csport &= ~cspinmask;
 #else
   digitalWrite(_dc, LOW);
-  digitalWrite(_sclk, LOW);
+  if(!hwSPI) digitalWrite(_sclk, LOW);
   digitalWrite(_cs, LOW);
 #endif
 
@@ -666,7 +666,7 @@ uint8_t Adafruit_ILI9341::readcommand8(uint8_t c, uint8_t index) {
    digitalWrite(_cs, HIGH);
 
    digitalWrite(_dc, LOW);
-   digitalWrite(_sclk, LOW);
+   if(!hwSPI) digitalWrite(_sclk, LOW);
    digitalWrite(_cs, LOW);
    spiwrite(c);
  

--- a/Adafruit_ILI9341.h
+++ b/Adafruit_ILI9341.h
@@ -30,7 +30,7 @@
 #endif
 
 
-#if defined (__AVR__) || defined(TEENSYDUINO) || defined (__arm__)
+#if defined (__AVR__) || defined(TEENSYDUINO) || defined (__arm__) || defined (ESP8266)
 #define USE_FAST_PINIO
 #endif
 
@@ -174,7 +174,9 @@ class Adafruit_ILI9341 : public Adafruit_GFX {
 #elif defined (ARDUINO_ARCH_ARC32)
     int8_t  _cs, _dc, _rst, _mosi, _miso, _sclk;
 #elif defined (ESP8266)
+    volatile uint32_t *mosiport, *clkport, *dcport, *rsport, *csport;
     int32_t  _cs, _dc, _rst, _mosi, _miso, _sclk;
+    uint32_t  mosipinmask, clkpinmask, cspinmask, dcpinmask;
 #endif
 };
 


### PR DESCRIPTION
`_mosi  = _sclk = -0;` would cause the library to keep toggling GPIO0, breaking it on the ESP8266 where GPIO0 is actually a useable pin. Also, enabling FAST_PINIO gives a small speed-up on the ESP8266, especially if using software-SPI:

With Software-SPI FAST_PINIO
Screen fill              4009176
Text                     207835
Lines                    1991692
Horiz/Vert Lines         327570
Rectangles (outline)     208932
Rectangles (filled)      8322126
Circles (filled)         1184832
Circles (outline)        871321
Triangles (outline)      631362
Triangles (filled)       2716238
Rounded rects (outline)  407425
Rounded rects (filled)   9059497
Done!

With Software-SPI no FAST_PINIO
Screen fill              4496967
Text                     236211
Lines                    2273287
Horiz/Vert Lines         367789
Rectangles (outline)     234832
Rectangles (filled)      9373581
Circles (filled)         1339961
Circles (outline)        994844
Triangles (outline)      720436
Triangles (filled)       3052686
Rounded rects (outline)  461837
Rounded rects (filled)   10164638
Done!
