### PR TITLE
Open cr support

### DIFF
--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -178,7 +178,7 @@ static inline uint8_t _avr_spi_read(void) {
 /*
  * Final SPI Macros
  * */
-#if defined (ARDUINO_ARCH_ARC32)
+#if defined (ARDUINO_ARCH_ARC32) || defined (ARDUINO_MAXIM)
 #define SPI_DEFAULT_FREQ         16000000
 #elif defined (__AVR__) || defined(TEENSYDUINO)
 #define SPI_DEFAULT_FREQ         8000000

--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -152,6 +152,14 @@
     #else
         #define HSPI_WRITE_PIXELS(c,l)   for(uint32_t i=0; i<((l)/2); i++){ SPI_WRITE16(((uint16_t*)(c))[i]); }
     #endif
+#elif defined(__OPENCR__)   // Define for Robotis __OPENCR__
+    #define SPI_HAS_WRITE_PIXELS
+    #define HSPI_READ()              SPI_OBJECT.transfer(0)
+    #define HSPI_WRITE(b)            SPI_OBJECT.write(b)
+    #define HSPI_WRITE16(s)          SPI_OBJECT.write16(s)
+    #define HSPI_WRITE32(l)          SPI_OBJECT.write32(l)
+    #define SPI_MAX_PIXELS_AT_ONCE  32
+    #define HSPI_WRITE_PIXELS(c,l)   SPI_OBJECT.writePixels(c,l)
 #else
     // Standard Byte-by-Byte SPI
 
@@ -178,7 +186,7 @@ static inline uint8_t _avr_spi_read(void) {
 /*
  * Final SPI Macros
  * */
-#if defined (ARDUINO_ARCH_ARC32) || defined (ARDUINO_MAXIM)
+#if defined (ARDUINO_ARCH_ARC32) || defined (ARDUINO_MAXIM) || defined(__OPENCR__)
 #define SPI_DEFAULT_FREQ         16000000
 #elif defined (__AVR__) || defined(TEENSYDUINO)
 #define SPI_DEFAULT_FREQ         8000000

--- a/Adafruit_ILI9341.h
+++ b/Adafruit_ILI9341.h
@@ -48,7 +48,7 @@
 #if defined(ARDUINO_STM32_FEATHER)
 typedef volatile uint32 RwReg;
 #endif
-#if defined(ARDUINO_FEATHER52)
+#if defined(ARDUINO_FEATHER52) || defined (ARDUINO_MAXIM)
 typedef volatile uint32_t RwReg;
 #endif
 
@@ -132,7 +132,7 @@ typedef volatile uint32_t RwReg;
 #define ILI9341_GREENYELLOW 0xAFE5      ///< 173, 255,  47
 #define ILI9341_PINK        0xFC18      ///< 255, 128, 192
 
-#if defined (ARDUINO_STM32_FEATHER)    // doesnt work on wiced feather
+#if defined (ARDUINO_STM32_FEATHER) || defined (ARDUINO_MAXIM)    // doesnt work on wiced feather
   #undef USE_FAST_PINIO
 #elif defined (__AVR__) || defined(TEENSYDUINO) || defined(ESP8266) || defined (ESP32) || defined(__arm__)
   #define USE_FAST_PINIO

--- a/Adafruit_ILI9341.h
+++ b/Adafruit_ILI9341.h
@@ -132,7 +132,7 @@ typedef volatile uint32_t RwReg;
 #define ILI9341_GREENYELLOW 0xAFE5      ///< 173, 255,  47
 #define ILI9341_PINK        0xFC18      ///< 255, 128, 192
 
-#if defined (ARDUINO_STM32_FEATHER) || defined (ARDUINO_MAXIM)    // doesnt work on wiced feather
+#if defined (ARDUINO_STM32_FEATHER) || defined (ARDUINO_MAXIM) ||  defined(__OPENCR__)    // doesnt work on these boards
   #undef USE_FAST_PINIO
 #elif defined (__AVR__) || defined(TEENSYDUINO) || defined(ESP8266) || defined (ESP32) || defined(__arm__)
   #define USE_FAST_PINIO

--- a/examples/fulltest_featherwing/fulltest_featherwing.ino
+++ b/examples/fulltest_featherwing/fulltest_featherwing.ino
@@ -56,6 +56,12 @@
    #define STMPE_CS 30
    #define SD_CS    27
 #endif
+#ifdef ARDUINO_MAX32620FTHR
+   #define TFT_DC   P5_4
+   #define TFT_CS   P5_3
+   #define STMPE_CS P3_3
+   #define SD_CS    P3_2
+#endif
 
 Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC);
 Adafruit_STMPE610 ts = Adafruit_STMPE610(STMPE_CS);

--- a/examples/fulltest_featherwing/fulltest_featherwing.ino
+++ b/examples/fulltest_featherwing/fulltest_featherwing.ino
@@ -56,7 +56,7 @@
    #define STMPE_CS 30
    #define SD_CS    27
 #endif
-#ifdef ARDUINO_MAX32620FTHR
+#if defined(ARDUINO_MAX32620FTHR) || defined(ARDUINO_MAX32630FTHR)
    #define TFT_DC   P5_4
    #define TFT_CS   P5_3
    #define STMPE_CS P3_3

--- a/examples/graphicstest_featherwing/graphicstest_featherwing.ino
+++ b/examples/graphicstest_featherwing/graphicstest_featherwing.ino
@@ -52,7 +52,7 @@
    #define STMPE_CS 30
    #define SD_CS    27
 #endif
-#ifdef ARDUINO_MAX32620FTHR
+#if defined(ARDUINO_MAX32620FTHR) || defined(ARDUINO_MAX32630FTHR)
    #define TFT_DC   P5_4
    #define TFT_CS   P5_3
    #define STMPE_CS P3_3

--- a/examples/graphicstest_featherwing/graphicstest_featherwing.ino
+++ b/examples/graphicstest_featherwing/graphicstest_featherwing.ino
@@ -52,6 +52,12 @@
    #define STMPE_CS 30
    #define SD_CS    27
 #endif
+#ifdef ARDUINO_MAX32620FTHR
+   #define TFT_DC   P5_4
+   #define TFT_CS   P5_3
+   #define STMPE_CS P3_3
+   #define SD_CS    P3_2
+#endif
 
 Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC);
 

--- a/examples/touchpaint_featherwing/touchpaint_featherwing.ino
+++ b/examples/touchpaint_featherwing/touchpaint_featherwing.ino
@@ -55,6 +55,12 @@
    #define STMPE_CS 30
    #define SD_CS    27
 #endif
+#ifdef ARDUINO_MAX32620FTHR
+   #define TFT_DC   P5_4
+   #define TFT_CS   P5_3
+   #define STMPE_CS P3_3
+   #define SD_CS    P3_2
+#endif
 
 Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC);
 Adafruit_STMPE610 ts = Adafruit_STMPE610(STMPE_CS);

--- a/examples/touchpaint_featherwing/touchpaint_featherwing.ino
+++ b/examples/touchpaint_featherwing/touchpaint_featherwing.ino
@@ -55,7 +55,7 @@
    #define STMPE_CS 30
    #define SD_CS    27
 #endif
-#ifdef ARDUINO_MAX32620FTHR
+#if defined(ARDUINO_MAX32620FTHR) || defined(ARDUINO_MAX32630FTHR)
    #define TFT_DC   P5_4
    #define TFT_CS   P5_3
    #define STMPE_CS P3_3


### PR DESCRIPTION
This update allows you to run on an Robotis OpenCR 1.0 board (http://www.robotis.us/opencr1-0/)

The changes were to add some sections of defines bases around #if defined(__OPENCR__), where it defines that it can not currently use the fast digitalWrites, plus the function names to use for different things like, what to use for Write16... 

Note: To work this requires current code from the Robotis OpenCR project in the develop branch.
The branch is located at: https://github.com/ROBOTIS-GIT/OpenCR/tree/develop. These changes should be propagated the next time Robotis updates their Arduino Board version.

I updated the SPI code on the OpenCR boards to use ESP32 like functions (SPI.write, write16, write32, writePixel).   

The main thing I tested it with was the graphic test example program. 
