### PR TITLE
fix formatting of links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ This is a library for the Adafruit ILI9341 display products
 
 This library works with the Adafruit 2.8" Touch Shield V2 (SPI)
   * http://www.adafruit.com/products/1651
+
 Adafruit 2.4" TFT LCD with Touchscreen Breakout w/MicroSD Socket - ILI9341
   * https://www.adafruit.com/product/2478
+
 2.8" TFT LCD with Touchscreen Breakout Board w/MicroSD Socket - ILI9341
   * https://www.adafruit.com/product/1770
+
 2.2" 18-bit color TFT LCD display with microSD card breakout - ILI9340
   * https://www.adafruit.com/product/1770
+
 TFT FeatherWing - 2.4" 320x240 Touchscreen For All Feathers 
   * https://www.adafruit.com/product/3315
 


### PR DESCRIPTION
The way GitHub renders README.md makes it look like the descriptions of links belong to the previous link. Adding a newline between each item fixes this.