### PR TITLE
Fix link to 2.2" display in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Adafruit 2.4" TFT LCD with Touchscreen Breakout w/MicroSD Socket - ILI9341
   * https://www.adafruit.com/product/1770
 
 2.2" 18-bit color TFT LCD display with microSD card breakout - ILI9340
-  * https://www.adafruit.com/product/1770
+  * https://www.adafruit.com/product/1480
 
 TFT FeatherWing - 2.4" 320x240 Touchscreen For All Feathers 
   * https://www.adafruit.com/product/3315


### PR DESCRIPTION
The link was a duplicate to 1770, which is the 2.8" display. 1480 is the correct product id for the 2.2" breakout board.
