### PR TITLE
Default to faster SPI for teensy 3.5/3.6

### DIFF
--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -57,6 +57,10 @@
 
 #if defined (ARDUINO_ARCH_ARC32) || defined (ARDUINO_MAXIM)
   #define SPI_DEFAULT_FREQ  16000000
+// TODO: check teensy 3.0/3.1/3.2 for faster SPI speed and
+// add them here if they work.
+#elif defined(__MK64FX512__) || defined(__MK66FX1M0__)
+  #define SPI_DEFAULT_FREQ  40000000
 #elif defined (__AVR__) || defined(TEENSYDUINO)
   #define SPI_DEFAULT_FREQ  8000000
 #elif defined(ESP8266) || defined(ESP32)

--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -57,9 +57,8 @@
 
 #if defined (ARDUINO_ARCH_ARC32) || defined (ARDUINO_MAXIM)
   #define SPI_DEFAULT_FREQ  16000000
-// TODO: check teensy 3.0/3.1/3.2 for faster SPI speed and
-// add them here if they work.
-#elif defined(__MK64FX512__) || defined(__MK66FX1M0__)
+// Teensy 3.0, 3.1/3.2, 3.5, 3.6
+#elif defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
   #define SPI_DEFAULT_FREQ  40000000
 #elif defined (__AVR__) || defined(TEENSYDUINO)
   #define SPI_DEFAULT_FREQ  8000000


### PR DESCRIPTION
This brings screenfill down from 954115  to 416305.
It's still twice as slow as it should/can be, but better than the previous value which is slower than even software SPI