### PR TITLE
Optimisation for RP2040

### DIFF
--- a/Adafruit_ILI9341.h
+++ b/Adafruit_ILI9341.h
@@ -150,6 +150,11 @@ public:
   void scrollTo(uint16_t y);
   void setScrollMargins(uint16_t top, uint16_t bottom);
 
+#if defined(ARDUINO_ARCH_RP2040)
+  // Override GFX for RP2040
+  void writePixel(int16_t x, int16_t y, uint16_t color);
+#endif
+
   // Transaction API not used by GFX
   void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+Raspberry PI Pico (RP2040) optimised to work with Earle Philhower's Arduino board package.
+
+
+
+
+
 # Adafruit ILI9341 Arduino Library [![Build Status](https://github.com/adafruit/Adafruit_ILI9341/workflows/Arduino%20Library%20CI/badge.svg)](https://github.com/adafruit/Adafruit_ILI9341/actions)[![Documentation](https://github.com/adafruit/ci-arduino/blob/master/assets/doxygen_badge.svg)](http://adafruit.github.io/Adafruit_ILI9341/html/index.html)
 
 This is a library for the Adafruit ILI9341 display products

--- a/examples/graphicstest/graphicstest.ino
+++ b/examples/graphicstest/graphicstest.ino
@@ -19,13 +19,23 @@
 #include "Adafruit_ILI9341.h"
 
 // For the Adafruit shield, these are the default.
-#define TFT_DC 9
-#define TFT_CS 10
+//#define TFT_DC 9
+//#define TFT_CS 10
+
+// For Raspberry Pi Pico (RP2040)
+// TFT MISO/SDO     connects to Pico pin D0 (GPIO 0)
+// TFT MOSI/SDI     connects to Pico pin D3 (GPIO 3)
+// TFT CLK/SCK/SCLK connects to Pico pin D2 (GPIO 2) 
+#define TFT_CS   D20  // Chip select control pin (GPIO 20)
+#define TFT_DC   D18  // Data Command control pin (GPIO 18)
+#define TFT_RST  D19  // Reset pin (GPIO 19)
 
 // Use hardware SPI (on Uno, #13, #12, #11) and the above for CS/DC
-Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC);
+//Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC);
 // If using the breakout, change pins as desired
 //Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC, TFT_MOSI, TFT_CLK, TFT_RST, TFT_MISO);
+// If using Raspberry Pi Pico (RP2040)
+Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC, TFT_RST);
 
 void setup() {
   Serial.begin(9600);

--- a/examples/graphicstest/graphicstest.ino
+++ b/examples/graphicstest/graphicstest.ino
@@ -40,8 +40,7 @@ Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC, TFT_RST);
 void setup() {
   Serial.begin(9600);
   Serial.println("ILI9341 Test!"); 
- 
-  tft.begin();
+  tft.begin(64000000); // Can set SPI clock rate
 
   // read diagnostics (optional but can help debug problems)
   uint8_t x = tft.readcommand8(ILI9341_RDMODE);

--- a/examples/pictureEmbed/pictureEmbed.ino
+++ b/examples/pictureEmbed/pictureEmbed.ino
@@ -50,7 +50,7 @@
 Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC, TFT_RST);
 
 void setup() {
-  tft.begin();
+  tft.begin(64000000); // Can set SPI clock rate
 }
 
 void loop(void) {

--- a/examples/pictureEmbed/pictureEmbed.ino
+++ b/examples/pictureEmbed/pictureEmbed.ino
@@ -27,17 +27,27 @@
 //#define TFT_CS 10
 
 // Feather 32u4 or M0 with TFT FeatherWing:
-#define TFT_DC 10
-#define TFT_CS  9
+//#define TFT_DC 10
+//#define TFT_CS  9
 // ESP8266:
 //#define TFT_DC 15
 //#define TFT_CS 0
+// Raspberry Pi Pico (RP2040)
+// TFT MISO/SDO     connects to Pico pin D0 (GPIO 0)
+// TFT MOSI/SDI     connects to Pico pin D3 (GPIO 3)
+// TFT CLK/SCK/SCLK connects to Pico pin D2 (GPIO 2) 
+#define TFT_CS   D20  // Chip select control pin (GPIO 20)
+#define TFT_DC   D18  // Data Command control pin (GPIO 18)
+#define TFT_RST  D19  // Reset pin (GPIO 19)
+
 // Other boards (including Feather boards) may have other pinouts;
 // see learn.adafruit.com/adafruit-2-4-tft-touch-screen-featherwing/pinouts
 
-Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC);
+//Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC);
 // If using the breakout, change pins as desired
 //Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC, TFT_MOSI, TFT_CLK, TFT_RST, TFT_MISO);
+// If using Raspberry Pi Pico (RP2040)
+Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC, TFT_RST);
 
 void setup() {
   tft.begin();


### PR DESCRIPTION
These changes plus a companion pull request for Adafruit_GFX provide performance benefits for the RP2040 based boards when used in hardware SPI mode.

I suspect this pull needs to be refactored since SPI code has been introduced herein which breaks the partioning with Adafruit_GFX library. Also, although this works with Earle Philhower's Arduino core and calls low level SPI code, it may not be compatible with the "official" Arduino RP2040 core.

![image](https://user-images.githubusercontent.com/15824805/113461232-a8aafe00-9413-11eb-98cb-98fd4027b2d0.png)
