### PR TITLE
Add Hardware Screen Rotation Option

### DIFF
--- a/Adafruit_ILI9341.h
+++ b/Adafruit_ILI9341.h
@@ -43,8 +43,14 @@
 #include <Adafruit_SPITFT_Macros.h>
 #include <SPI.h>
 
-#define ILI9341_TFTWIDTH 240  ///< ILI9341 max TFT width
-#define ILI9341_TFTHEIGHT 320 ///< ILI9341 max TFT height
+//Allow TFT Width / Height override, MUST define these
+//above the include line for this file to work.
+#ifndef ILI9341_TFTWIDTH
+  #define ILI9341_TFTWIDTH 240  ///< ILI9341 max TFT width
+#endif
+#ifndef ILI9341_TFTHEIGHT
+  #define ILI9341_TFTHEIGHT 320 ///< ILI9341 max TFT height
+#endif
 
 #define ILI9341_NOP 0x00     ///< No-op register
 #define ILI9341_SWRESET 0x01 ///< Software reset register

--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ To download. click the DOWNLOADS button in the top right corner, rename the unco
 Place the Adafruit_ILI9341 library folder your arduinosketchfolder/libraries/ folder. You may need to create the libraries subfolder if its your first library. Restart the IDE
 
 Also requires the Adafruit_GFX library for Arduino.
+
+**UNSUPPORTED Advanced Options**
+You can change the TFT Width/Height by adding the below two lines ABOCE the include line for this library.  
+** NOTE: This is only for displays of different sizes, or specifically if your screen is showing only on 3/4 of your display, and 1/4 is jibberish, you likely need to use the two lines below.  
+
+#define ILI9341_TFTHEIGHT 240
+#define ILI9341_TFTWIDTH  320
+
+#include "Adafruit_ILI9341.h"
+


### PR DESCRIPTION
This simple change, allows this library to work with non-Adafruit ILI9341 displays with a Landscape not Portrait hardware screen orientation.  

Notations added to code and readme.md