### PR TITLE
Fix computation in scrollMargin

### DIFF
--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -277,7 +277,7 @@ void Adafruit_ILI9341::scrollTo(uint16_t y) {
 void Adafruit_ILI9341::setScrollMargins(uint16_t top, uint16_t bottom) {
   // TFA+VSA+BFA must equal 320
   if (top + bottom <= ILI9341_TFTHEIGHT) {
-    uint16_t middle = ILI9341_TFTHEIGHT - top + bottom;
+    uint16_t middle = ILI9341_TFTHEIGHT - (top + bottom);
     uint8_t data[6];
     data[0] = top >> 8;
     data[1] = top & 0xff;


### PR DESCRIPTION
as per issue #62

The function does not work as the computation of middle was incorrect.
it either needed to be
 uint16_t middle = ILI9341_TFTHEIGHT - top - bottom;

or what I prefer and did:
uint16_t middle = ILI9341_TFTHEIGHT - (top + bottom);

