### PR TITLE
Small changes to the mandelbrot example

### DIFF
--- a/examples/mandelbrot/mandelbrot.ino
+++ b/examples/mandelbrot/mandelbrot.ino
@@ -14,15 +14,15 @@
 #else
   // Use SPI
   #define STMPE_CS 6
-  #define TFT_CS   9
-  #define TFT_DC   10
+  #define TFT_CS   10
+  #define TFT_DC   9
   #define SD_CS    5
   Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC);
 #endif
 
 
 const int16_t
-  bits        = 20,   // Fractional resolution
+  bits        = 12,   // Fractional resolution
   pixelWidth  = 320,  // TFT dimensions
   pixelHeight = 240,
   iterations  = 128;  // Fractal iteration limit or 'dwell'
@@ -37,7 +37,7 @@ float
 #endif
 
 void setup(void) {
-  Serial.begin(115200);
+  Serial.begin(9600);
   Serial.print("Mandelbrot drawer!");
 
   tft.begin();


### PR DESCRIPTION
Changes:
- flipped the CS and DC pins so it will work on the ILI9341 Adafruit Shield out of the box
- decreased the resolution from 20 bits to 12 bits (anything higher than this will result in a orange screen , at least on my setup) 
- changed the baud rate so all the examples will have the same baud rate

Tested on :
- Arduino MEGA 2560
- ILI9341 Adafruit display with capacitive touch