### PR TITLE
Use int16_t for pins instead of int8_t

### DIFF
--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -92,8 +92,8 @@
     @param    miso  SPI MISO pin # (optional, pass -1 if unused)
 */
 /**************************************************************************/
-Adafruit_ILI9341::Adafruit_ILI9341(int8_t cs, int8_t dc, int8_t mosi,
-                                   int8_t sclk, int8_t rst, int8_t miso)
+Adafruit_ILI9341::Adafruit_ILI9341(int16_t cs, int16_t dc, int16_t mosi,
+                                   int16_t sclk, int16_t rst, int16_t miso)
     : Adafruit_SPITFT(ILI9341_TFTWIDTH, ILI9341_TFTHEIGHT, cs, dc, mosi, sclk,
                       rst, miso) {}
 
@@ -106,7 +106,7 @@ Adafruit_ILI9341::Adafruit_ILI9341(int8_t cs, int8_t dc, int8_t mosi,
     @param  rst  Reset pin # (optional, pass -1 if unused).
 */
 /**************************************************************************/
-Adafruit_ILI9341::Adafruit_ILI9341(int8_t cs, int8_t dc, int8_t rst)
+Adafruit_ILI9341::Adafruit_ILI9341(int16_t cs, int16_t dc, int16_t rst)
     : Adafruit_SPITFT(ILI9341_TFTWIDTH, ILI9341_TFTHEIGHT, cs, dc, rst) {}
 
 #if !defined(ESP8266)
@@ -121,8 +121,8 @@ Adafruit_ILI9341::Adafruit_ILI9341(int8_t cs, int8_t dc, int8_t rst)
     @param  rst       Reset pin # (optional, pass -1 if unused).
 */
 /**************************************************************************/
-Adafruit_ILI9341::Adafruit_ILI9341(SPIClass *spiClass, int8_t dc, int8_t cs,
-                                   int8_t rst)
+Adafruit_ILI9341::Adafruit_ILI9341(SPIClass *spiClass, int16_t dc, int16_t cs,
+                                   int16_t rst)
     : Adafruit_SPITFT(ILI9341_TFTWIDTH, ILI9341_TFTHEIGHT, spiClass, cs, dc,
                       rst) {}
 #endif // end !ESP8266
@@ -142,8 +142,8 @@ Adafruit_ILI9341::Adafruit_ILI9341(SPIClass *spiClass, int8_t dc, int8_t cs,
     @param  rd        Read strobe pin # (optional, pass -1 if unused).
 */
 /**************************************************************************/
-Adafruit_ILI9341::Adafruit_ILI9341(tftBusWidth busWidth, int8_t d0, int8_t wr,
-                                   int8_t dc, int8_t cs, int8_t rst, int8_t rd)
+Adafruit_ILI9341::Adafruit_ILI9341(tftBusWidth busWidth, int16_t d0, int16_t wr,
+                                   int16_t dc, int16_t cs, int16_t rst, int16_t rd)
     : Adafruit_SPITFT(ILI9341_TFTWIDTH, ILI9341_TFTHEIGHT, busWidth, d0, wr, dc,
                       cs, rst, rd) {}
 

--- a/Adafruit_ILI9341.h
+++ b/Adafruit_ILI9341.h
@@ -133,15 +133,15 @@ work with ILI9340)
 
 class Adafruit_ILI9341 : public Adafruit_SPITFT {
 public:
-  Adafruit_ILI9341(int8_t _CS, int8_t _DC, int8_t _MOSI, int8_t _SCLK,
-                   int8_t _RST = -1, int8_t _MISO = -1);
-  Adafruit_ILI9341(int8_t _CS, int8_t _DC, int8_t _RST = -1);
+  Adafruit_ILI9341(int16_t _CS, int16_t _DC, int16_t _MOSI, int16_t _SCLK,
+                   int16_t _RST = -1, int16_t _MISO = -1);
+  Adafruit_ILI9341(int16_t _CS, int16_t _DC, int16_t _RST = -1);
 #if !defined(ESP8266)
-  Adafruit_ILI9341(SPIClass *spiClass, int8_t dc, int8_t cs = -1,
-                   int8_t rst = -1);
+  Adafruit_ILI9341(SPIClass *spiClass, int16_t dc, int16_t cs = -1,
+                   int16_t rst = -1);
 #endif // end !ESP8266
-  Adafruit_ILI9341(tftBusWidth busWidth, int8_t d0, int8_t wr, int8_t dc,
-                   int8_t cs = -1, int8_t rst = -1, int8_t rd = -1);
+  Adafruit_ILI9341(tftBusWidth busWidth, int16_t d0, int16_t wr, int16_t dc,
+                   int16_t cs = -1, int16_t rst = -1, int16_t rd = -1);
 
   void begin(uint32_t freq = 0);
   void setRotation(uint8_t r);


### PR DESCRIPTION
As I said on https://github.com/adafruit/Adafruit-GFX-Library/pull/399, I could use PA4 pin (204) as CS with this code.
Thank you.