### PR TITLE
Only include wiring_private.h if it exists (Arduino UNO R4 support)

### DIFF
--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -50,7 +50,11 @@
 #ifndef ARDUINO_STM32_FEATHER
 #include "pins_arduino.h"
 #ifndef RASPI
-#include "wiring_private.h"
+#if defined __has_include
+#  if __has_include ("wiring_private.h")
+#    include "wiring_private.h"
+#  endif
+#endif
 #endif
 #endif
 #include <limits.h>

--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -50,7 +50,7 @@
 #ifndef ARDUINO_STM32_FEATHER
 #include "pins_arduino.h"
 #ifndef RASPI
-#if defined __has_include
+#if defined(__has_include)
 #if __has_include("wiring_private.h")
 #include "wiring_private.h"
 #else  //defined(__has_include)

--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -53,6 +53,8 @@
 #if defined __has_include
 #if __has_include("wiring_private.h")
 #include "wiring_private.h"
+#else  //defined(__has_include)
+#include "wiring_private.h"
 #endif
 #endif
 #endif

--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -51,9 +51,9 @@
 #include "pins_arduino.h"
 #ifndef RASPI
 #if defined __has_include
-#  if __has_include ("wiring_private.h")
-#    include "wiring_private.h"
-#  endif
+#if __has_include ("wiring_private.h")
+#include "wiring_private.h"
+#endif
 #endif
 #endif
 #endif

--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -51,7 +51,7 @@
 #include "pins_arduino.h"
 #ifndef RASPI
 #if defined __has_include
-#if __has_include ("wiring_private.h")
+#if __has_include("wiring_private.h")
 #include "wiring_private.h"
 #endif
 #endif


### PR DESCRIPTION
Some of the new Arduino cores do not include this file.  This includes the cores for the Arduino UNO Rev 4.

The change is limited to use the __has_include() preprocessor stuff be used to limit when arduino_private.h is included.

Two ways to fix this.
1) add it specifically to a list of cores to not include it, like this file has #ifndef RASPI

Or use GCC __has_include to detect it and then include it. With Arduino this will not work well for library headers, as the library search stuff will not see this as a dependency and as such won't add the -I to command line to find it.  But this file is in core which is always on the search path

I ran this modified version on the UNO R4 Minima with the graphictest example.