### PR TITLE
Teensy 4 should use fast SPI like T3.x, not 8 MHz like Teensy 2.x

### DIFF
--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -59,7 +59,8 @@
 #define SPI_DEFAULT_FREQ 16000000
 // Teensy 3.0, 3.1/3.2, 3.5, 3.6
 #elif defined(__MK20DX128__) || defined(__MK20DX256__) ||                      \
-    defined(__MK64FX512__) || defined(__MK66FX1M0__)
+    defined(__MK64FX512__) || defined(__MK66FX1M0__) ||                        \
+    defined(ARDUINO_TEENSY40) || defined(ARDUINO_TEENSY41)
 #define SPI_DEFAULT_FREQ 40000000
 #elif defined(__AVR__) || defined(TEENSYDUINO)
 #define SPI_DEFAULT_FREQ 8000000


### PR DESCRIPTION
Previously, if one were using this library with a Teensy 4.0 or 4.1, it would use the Teensy 2 SPI speed of 8 MHz because the code was written before T4 existed, and `TEENSYDUINO` is still defined. However, Teensy 4.x is faster than T3.x, and should at minimum use the same speed as T3.x (40 MHz). This PR fixes that. 

Empirically I tested an ILI9341 display with 80MHz on the teensy 4.1 and it handled that fine too -- happy to change the define to that too if anyone feels it necessary (although i havent verified the chip is spec'd to operate at that speed, and that will make more sensitive to trace capacitance).