### PR TITLE
Add CMakeLists.txt to support ESP-IDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Adafruit ILI9341 Library
+# MIT License
+
+cmake_minimum_required(VERSION 3.5)
+
+idf_component_register(SRCS "Adafruit_ILI9341.cpp" INCLUDE_DIRS "." REQUIRES Adafruit-GFX-Library arduino-esp32)
+
+project(Adafruit_ILI9341)


### PR DESCRIPTION
This allows this library to be built from ESP-IDF.

See also where this was done for [Adafruit-GFX-Library](https://github.com/adafruit/Adafruit-GFX-Library/pull/376)