### PR TITLE
Add a setRotation overload that supports mirroring the display.

### DIFF
--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -246,6 +246,61 @@ void Adafruit_ILI9341::setRotation(uint8_t m) {
 
 /**************************************************************************/
 /*!
+    @brief   Set origin of (0,0) and orientation of TFT display
+    @param   m  The index for rotation, from 0-3 inclusive
+    @param   mirrored True to mirror display, false to keep display as-is
+*/
+/**************************************************************************/
+void Adafruit_ILI9341::setRotation(uint8_t m, bool mirrored) {
+  rotation = m % 4; // can't be higher than 3
+  switch (rotation) {
+  case 0:
+    if (mirrored) {
+        m = (MADCTL_BGR);
+    }
+    else {
+        m = (MADCTL_MX | MADCTL_BGR);
+    }
+    _width = ILI9341_TFTWIDTH;
+    _height = ILI9341_TFTHEIGHT;
+    break;
+  case 1:
+    if (mirrored) {
+        m = (MADCTL_MY | MADCTL_MV | MADCTL_BGR);
+    }
+    else {
+      m = (MADCTL_MV | MADCTL_BGR);
+    }
+    _width = ILI9341_TFTHEIGHT;
+    _height = ILI9341_TFTWIDTH;
+    break;
+  case 2:
+    if (mirrored) {
+      m = (MADCTL_MX | MADCTL_MY | MADCTL_BGR);
+    }
+    else {
+      m = (MADCTL_MY | MADCTL_BGR);
+    }
+    _width = ILI9341_TFTWIDTH;
+    _height = ILI9341_TFTHEIGHT;
+    break;
+  case 3:
+    if (mirrored) {
+      m = (MADCTL_MX | MADCTL_MV | MADCTL_BGR);
+    }
+    else {
+      m = (MADCTL_MX | MADCTL_MY | MADCTL_MV | MADCTL_BGR);
+    }
+    _width = ILI9341_TFTHEIGHT;
+    _height = ILI9341_TFTWIDTH;
+    break;
+  }
+
+  sendCommand(ILI9341_MADCTL, &m, 1);
+}
+
+/**************************************************************************/
+/*!
     @brief   Enable/Disable display color inversion
     @param   invert True to invert, False to have normal color
 */

--- a/Adafruit_ILI9341.h
+++ b/Adafruit_ILI9341.h
@@ -145,6 +145,7 @@ public:
 
   void begin(uint32_t freq = 0);
   void setRotation(uint8_t r);
+  void setRotation(uint8_t r, bool mirrored);
   void invertDisplay(bool i);
   void scrollTo(uint16_t y);
   void setScrollMargins(uint16_t top, uint16_t bottom);


### PR DESCRIPTION
# Issue

There was no method in this library allowed a user to mirror a display. This can be useful in cases where you would want the display to reflect off a surface (ex. [a automobile hud](https://en.wikipedia.org/wiki/Automotive_head-up_display)).

# Scope of changes

The actual code change is limited to the main library, overloading the existing `Adafruit_ILI9341::setRotation` class function. However, this may have broader implications for the library as a whole depending on how draw functions are implemented. That being said, in my testing I ran into no issues.

## Limitations
This change was only tested on an Uno platform with a generic shield. However, as this only changes ILI9341 register values, I seriously doubt there any compatibility issues across platforms.

# Testing

The simplest way to test this is with a modified example:

```c++
#include "SPI.h"
#include "Adafruit_GFX.h"
#include "Adafruit_ILI9341.h"

// For the Adafruit shield, these are the default.
#define TFT_DC 9
#define TFT_CS 10

// Use hardware SPI (on Uno, #13, #12, #11) and the above for CS/DC
Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC);
// If using the breakout, change pins as desired
//Adafruit_ILI9341 tft = Adafruit_ILI9341(TFT_CS, TFT_DC, TFT_MOSI, TFT_CLK, TFT_RST, TFT_MISO);

void setup() {
  Serial.begin(9600);
  Serial.println("ILI9341 Test!"); 
 
  tft.begin();

  // read diagnostics (optional but can help debug problems)
  uint8_t x = tft.readcommand8(ILI9341_RDMODE);
  Serial.print("Display Power Mode: 0x"); Serial.println(x, HEX);
  x = tft.readcommand8(ILI9341_RDMADCTL);
  Serial.print("MADCTL Mode: 0x"); Serial.println(x, HEX);
  x = tft.readcommand8(ILI9341_RDPIXFMT);
  Serial.print("Pixel Format: 0x"); Serial.println(x, HEX);
  x = tft.readcommand8(ILI9341_RDIMGFMT);
  Serial.print("Image Format: 0x"); Serial.println(x, HEX);
  x = tft.readcommand8(ILI9341_RDSELFDIAG);
  Serial.print("Self Diagnostic: 0x"); Serial.println(x, HEX); 
  
  Serial.println(F("Benchmark                Time (microseconds)"));
  delay(10);
  Serial.print(F("Screen fill              "));
  Serial.println(testFillScreen());
  delay(500);

  Serial.print(F("Text                     "));
  Serial.println(testText());
  delay(3000);

  Serial.println(F("Done!"));

}


void loop(void) {
  for(uint8_t rotation=0; rotation<4; rotation++) {
    //regular display
    tft.setRotation(rotation, false);
    testText();
    delay(500);
    //mirrored display
    tft.setRotation(rotation, true);
    testText();
    delay(1000);
  }
}

unsigned long testFillScreen() {
  unsigned long start = micros();
  tft.fillScreen(ILI9341_BLACK);
  yield();
  tft.fillScreen(ILI9341_RED);
  yield();
  tft.fillScreen(ILI9341_GREEN);
  yield();
  tft.fillScreen(ILI9341_BLUE);
  yield();
  tft.fillScreen(ILI9341_BLACK);
  yield();
  return micros() - start;
}

unsigned long testText() {
  tft.fillScreen(ILI9341_BLACK);
  unsigned long start = micros();
  tft.setCursor(0, 0);
  tft.setTextColor(ILI9341_WHITE);  tft.setTextSize(1);
  tft.println("Hello World!");
  tft.setTextColor(ILI9341_YELLOW); tft.setTextSize(2);
  tft.println(1234.56);
  tft.setTextColor(ILI9341_RED);    tft.setTextSize(3);
  tft.println(0xDEADBEEF, HEX);
  tft.println();
  tft.setTextColor(ILI9341_GREEN);
  tft.setTextSize(5);
  tft.println("Groop");
  tft.setTextSize(2);
  tft.println("I implore thee,");
  tft.setTextSize(1);
  tft.println("my foonting turlingdromes.");
  tft.println("And hooptiously drangle me");
  tft.println("with crinkly bindlewurdles,");
  tft.println("Or I will rend thee");
  tft.println("in the gobberwarts");
  tft.println("with my blurglecruncheon,");
  tft.println("see if I don't!");
  return micros() - start;
}
```

This should display the test text in one orientation, then mirror it, before rotating to the next orientation.