### PR TITLE
Add support for Zephyr based boards such as UNO Q

### DIFF
--- a/Adafruit_ILI9341.cpp
+++ b/Adafruit_ILI9341.cpp
@@ -47,7 +47,7 @@
  */
 
 #include "Adafruit_ILI9341.h"
-#ifndef ARDUINO_STM32_FEATHER
+#if !defined(ARDUINO_STM32_FEATHER) && !defined(ARDUINO_ARCH_ZEPHYR)
 #include "pins_arduino.h"
 #if !defined(RASPI) && !defined(ARDUINO_UNOR4_MINIMA) &&                       \
     !defined(ARDUINO_UNOR4_WIFI)


### PR DESCRIPTION
Same issue as the ST7735 library:
https://github.com/adafruit/Adafruit-ST7735-Library/pull/222

The zephyr boards do not define pins_arduino.h nor wiring_private.h So updated the file to exclude 
them in much the same was as UNO R4 boards.

Verified it built for Portenta H7 running Zephyr.  Ran the graphics test after updating the pin number
It ran fine.